### PR TITLE
fix(layout): 修复窗口最大化导致 Sidebar/Top Bar 被隐藏的问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import Navbar from './layout/Navbar.vue';
 import Sidebar from './layout/Sidebar.vue';
@@ -87,6 +87,12 @@ const isPlayerRoute = computed(() => {
 const shouldHidePlayerChrome = computed(() => (
   isPlayerRoute.value && isPlayerFullscreen.value
 ));
+
+watch(isPlayerRoute, (isPlayer) => {
+  if (!isPlayer) {
+    isPlayerFullscreen.value = false;
+  }
+});
 
 const toggleSidebar = () => {
   isSidebarCollapsed.value = !isSidebarCollapsed.value;
@@ -150,7 +156,7 @@ const handleReorderListStore = (reorderedList: FollowedStreamer[]) => {
 };
 
 const handleFullscreenChange = (isFullscreen: boolean) => {
-  isPlayerFullscreen.value = isFullscreen;
+  isPlayerFullscreen.value = isPlayerRoute.value ? isFullscreen : false;
 };
 </script>
 


### PR DESCRIPTION
## 问题                                                                                                                                                                                                                                                       
在进入直播间后，如果窗口处于最大化状态，Sidebar 和 Top Bar 会被隐藏，且部分场景无法恢复。                                                                                                                                                                      原因是全屏状态存在状态残留和误判          

## 变更内容                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
1. src/App.vue
  - 增加播放器路由监听：离开播放器路由时强制重置 isPlayerFullscreen = false。
  - 增强 handleFullscreenChange 防护：仅在播放器路由内接受全屏状态，避免非播放器场景污染布局状态。
2. src/components/player/index.vue
  - 对 cssFullscreen_change 回调入参做归一化处理，避免异常 payload 导致“最大化被误判为全屏”。
  - 在播放器关闭和卸载阶段显式 emit('fullscreen-change', false)，防止父层状态残留。
  - 组件挂载时增加一次 fullscreen-change(false) 兜底初始化，确保进入页面时状态干净。      

## 验证情况
已完成Windows平台下的手动编译与验证                                                                                                                                                                                         